### PR TITLE
turn on gzip for TTF font files

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -17,7 +17,7 @@ http {
         error_page 400 403 404 /404;
         gzip on;
         gzip_types application/javascript application/json image/svg+xml text/css
-            text/plain application/font-ttf;
+            text/plain font/ttf;
         gzip_vary on;
         listen 8081;
         location = /404 {

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,7 +17,7 @@ http {
         error_page 400 403 404 /404;
         gzip on;
         gzip_types application/javascript application/json image/svg+xml text/css
-            text/plain;
+            text/plain application/font-ttf;
         gzip_vary on;
         listen 8081;
         location = /404 {
@@ -37,8 +37,6 @@ http {
             proxy_http_version 1.1;
             proxy_intercept_errors on;
             proxy_pass https://s3.csh.rit.edu$request_uri;
-            gzip            on;
-            gzip_types      application/font-ttf;
         }
         resolver 8.8.8.8;
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -37,6 +37,8 @@ http {
             proxy_http_version 1.1;
             proxy_intercept_errors on;
             proxy_pass https://s3.csh.rit.edu$request_uri;
+            gzip            on;
+            gzip_types      application/font-ttf;
         }
         resolver 8.8.8.8;
     }


### PR DESCRIPTION
added a couple lines of config to `nginx.conf`to turn on gzip compression for `.ttf` fonts. 


fixes #13 

